### PR TITLE
Force authentication on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project includes code originally developed by Anthropic, PBC, licensed unde
 ### Tools
 
 - **gdrive_search**
+
   - **Description**: Search for files in Google Drive.
   - **Input**:
     - `query` (string): Search query.
@@ -17,12 +18,14 @@ This project includes code originally developed by Anthropic, PBC, licensed unde
   - **Output**: Returns file names and MIME types of matching files.
 
 - **gdrive_read_file**
+
   - **Description**: Read contents of a file from Google Drive.
   - **Input**:
     - `fileId` (string): ID of the file to read.
   - **Output**: Returns the contents of the specified file.
 
 - **gsheets_read**
+
   - **Description**: Read data from a Google Spreadsheet with flexible options for ranges and formatting.
   - **Input**:
     - `spreadsheetId` (string): The ID of the spreadsheet to read.
@@ -57,18 +60,30 @@ The server provides access to Google Drive files:
 2. [Enable the Google Drive API](https://console.cloud.google.com/workspace-api/products)
 3. [Configure an OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent) ("internal" is fine for testing)
 4. Add OAuth scopes `https://www.googleapis.com/auth/drive.readonly`, `https://www.googleapis.com/auth/spreadsheets`
-5. [Create an OAuth Client ID](https://console.cloud.google.com/apis/credentials/oauthclient) for application type "Desktop App"
-6. Download the JSON file of your client's OAuth keys
-7. Rename the key file to `gcp-oauth.keys.json` and place into the path you specify with `GDRIVE_CREDS_DIR` (i.e. `/Users/username/.config/mcp-gdrive`)
-8. Note your OAuth Client ID and Client Secret. They must be provided as environment variables along with your configuration directory.
+5. In order to allow interaction with sheets and docs you will also need to enable the [Google Sheets API](https://console.cloud.google.com/apis/api/sheets.googleapis.com/) and [Google Docs API](https://console.cloud.google.com/marketplace/product/google/docs.googleapis.com) in your workspaces Enabled API and Services section.
+6. [Create an OAuth Client ID](https://console.cloud.google.com/apis/credentials/oauthclient) for application type "Desktop App"
+7. Download the JSON file of your client's OAuth keys
+8. Rename the key file to `gcp-oauth.keys.json` and place into the path you specify with `GDRIVE_CREDS_DIR` (i.e. `/Users/username/.config/mcp-gdrive`)
+9. Note your OAuth Client ID and Client Secret. They must be provided as environment variables along with your configuration directory.
+10. You will also need to setup a .env file within the project with the following fields. You can find the Client ID and Client Secret in the Credentials section of the Google Cloud Console.
+
+```
+GDRIVE_CREDS_DIR=/path/to/config/directory
+CLIENT_ID=<CLIENT_ID>
+CLIENT_SECRET=<CLIENT_SECRET>
+```
 
 Make sure to build the server with either `npm run build` or `npm run watch`.
 
 ### Authentication
 
-Before making requests to Google's APIs, you will be prompted to authenticate with your browser. You must authenticate with an account in the same organization as your Google Cloud project.
+Next you will need to run `node ./dist/index.js` to trigger the authentication step
+
+You will be prompted to authenticate with your browser. You must authenticate with an account in the same organization as your Google Cloud project.
 
 Your OAuth token is saved in the directory specified by the `GDRIVE_CREDS_DIR` environment variable.
+
+![Authentication Prompt](https://imgur.com/a/dUNT7xb)
 
 ### Usage with Desktop App
 
@@ -79,10 +94,7 @@ To integrate this server with the desktop app, add the following to your app's s
   "mcpServers": {
     "gdrive": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@isaacphi/mcp-gdrive"
-      ],
+      "args": ["-y", "@isaacphi/mcp-gdrive"],
       "env": {
         "CLIENT_ID": "<CLIENT_ID>",
         "CLIENT_SECRET": "<CLIENT_SECRET>",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You will be prompted to authenticate with your browser. You must authenticate wi
 
 Your OAuth token is saved in the directory specified by the `GDRIVE_CREDS_DIR` environment variable.
 
-![Authentication Prompt](https://imgur.com/a/dUNT7xb)
+![Authentication Prompt](https://i.imgur.com/TbyV6Yq.png)
 
 ### Usage with Desktop App
 

--- a/index.ts
+++ b/index.ts
@@ -129,6 +129,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function startServer() {
   try {
     console.log("Starting server");
+    
+    // Add this line to force authentication at startup
+    await ensureAuth(); // This will trigger the auth flow if no valid credentials exist
+    
     const transport = new StdioServerTransport();
     await server.connect(transport);
 

--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 async function startServer() {
   try {
-    console.log("Starting server");
+    console.error("Starting server");
     
     // Add this line to force authentication at startup
     await ensureAuth(); // This will trigger the auth flow if no valid credentials exist


### PR DESCRIPTION
Nice work on this updated version of mcp gdrive. I was dismayed to find the original version of gdrive did nothing other than read file names. Yours is way more useful! 

Anyway when I tried implementing this I kept running into an issue of not being able to get the authentication flow to trigger when I run the compiled file in the ./dist directory. I believe the startServer() function in the index.js was not actually triggering the correct flow upon starting the server.

I made a couple of small changes:
- modified the startServer() function to force authentication on startup
```js
async function startServer() {
  try {
    console.log("Starting server");
    
    // Add this line to force authentication at startup
    await ensureAuth(); // This will trigger the auth flow if no valid credentials exist
    
    const transport = new StdioServerTransport();
    await server.connect(transport);

    // Set up periodic token refresh that never prompts for auth
    setupTokenRefresh();
  } catch (error) {
    console.error("Error starting server:", error);
    process.exit(1);
  }
}
```

- updated the README to:
1. explicitly state that the user needs to enable the Google Sheets and Docs API in their workspace for full functionality
2. that the user needs to include a .env file in their project with the relevant secrets
3. that the user needs to run `node ./dist/index.js` to trigger the authentication step

Once I did that I was able to get the mcp server connected properly to the client; although I am seeing this error upon starting Claude Desktop but it doesn't actually effect functionality. All of the tools show up and work as expected. I assume this is coming from a syntax error when Claude MCP Client parses the @isaacphi/mcp-gdrive npm package.

Suggested fix might be to replace the console.log with a `console.error("Starting server")` but idk I can't test that.

<img width="574" alt="image" src="https://github.com/user-attachments/assets/2f47fed3-d891-46f7-8868-8a339a2de8e6" />


